### PR TITLE
fix(android): support AGP 9 built-in Kotlin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to `advanced_haptics` will be documented in this file.
 
 ---
 
+## Unreleased
+
+- **FIX:** Added support for AGP 9 built-in Kotlin while preserving compatibility with projects that still use the external Kotlin Gradle Plugin. ([#6](https://github.com/miracle101000/advanced_haptics/issues/6))
+
+---
+
 ## 1.0.8
 Updated ReadMe
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -21,8 +21,15 @@ allprojects {
     }
 }
 
+// AGP 9 can still run in compatibility mode, so inspect the actual consumer property.
+def builtInKotlinEnabled = (project.findProperty('android.builtInKotlin') ?: 'false')
+        .toString()
+        .toBoolean()
+
 apply plugin: 'com.android.library'
-apply plugin: 'kotlin-android'
+if (!builtInKotlinEnabled) {
+    apply plugin: 'kotlin-android'
+}
 
 android {
     if (project.android.hasProperty("namespace")) {
@@ -36,8 +43,10 @@ android {
         targetCompatibility JavaVersion.VERSION_1_8
     }
 
-    kotlinOptions {
-        jvmTarget = '1.8'
+    if (!builtInKotlinEnabled) {
+        kotlinOptions {
+            jvmTarget = '1.8'
+        }
     }
 
     sourceSets {


### PR DESCRIPTION
Fixes #6